### PR TITLE
Fixed small spelling mistake

### DIFF
--- a/src/main/java/com/communitysurvivalgames/thesurvivalgames/ConfigurationData.java
+++ b/src/main/java/com/communitysurvivalgames/thesurvivalgames/ConfigurationData.java
@@ -74,7 +74,7 @@ public class ConfigurationData {
 	}
 
 	public List<String> getWelcomeMessage() {
-		return this.config.getStringList("welocme-message");
+		return this.config.getStringList("welcome-message");
 	}
 
 }


### PR DESCRIPTION
Changed spelling of "welocme" to "welcome". Resulting in correct reference to the node in the config.yml
